### PR TITLE
recognize zenpower3 cpu temperature sensor

### DIFF
--- a/src/monitor/cpu.rs
+++ b/src/monitor/cpu.rs
@@ -13,7 +13,7 @@ pub fn find_temp_sensor() -> String {
         match read_to_string(format!("/sys/class/hwmon/hwmon{i}/name")) {
             Ok(data) => {
                 let hwname = data.trim_end();
-                if hwname == "k10temp" || hwname == "coretemp" {
+                if ["k10temp", "coretemp", "zenpower"].contains(&hwname) {
                     return format!("/sys/class/hwmon/hwmon{i}/temp1_input");
                 }
             },


### PR DESCRIPTION
recognize cpu temperature sensor from [zenpower3 driver](https://git.exozy.me/a/zenpower3),
an alternate driver for reading temperature from certain Ryzen CPUs, and quite a bit more sensors data that what `k10temp` could read normally

it should be reading temps from `Tdie` by default

---

just got myself an AK500 digital for main desktop (dual booting win11/arch) with this driver set up sometimes before,
and this driver can't be loaded at the same time with `k10temp` so this patch is needed to get it working on my setup

<details><summary>sample sensors output for zenpower3 driver</summary>
<p>

```
% sensors -u zenpower-\*
zenpower-pci-00c3
Adapter: PCI adapter
SVI2_Core:
  in1_input: 1.257
SVI2_SoC:
  in2_input: 1.188
Tdie:
  temp1_input: 43.000
  temp1_max: 95.000
Tctl:
  temp2_input: 43.000
Tccd1:
  temp3_input: 42.250
SVI2_P_Core:
  power1_input: 15.646
SVI2_P_SoC:
  power2_input: 16.082
SVI2_C_Core:
  curr1_input: 15.152
SVI2_C_SoC:
  curr2_input: 13.537
```

</p>
</details> 