### PR TITLE
Implement custom mode and number display (Only for AK*** so far).

### DIFF
--- a/src/custom_mode.rs
+++ b/src/custom_mode.rs
@@ -1,0 +1,23 @@
+pub struct CustomModeItem {
+    pub mode: String,
+    pub tick_length: u8,
+}
+
+impl CustomModeItem {
+    pub fn parse(input: &str) -> Self {
+        let mut parts = input.split(",");
+        let Some(mode) = parts.next().map(&str::to_string) else { panic!("Need at least the mode parameter") };
+        let tick_length = match parts.next() {
+            None => 8u8,
+            Some(val) => val.parse().unwrap(),
+        };
+        Self {
+            mode: mode.to_string(),
+            tick_length,
+        }
+    }
+
+    pub fn parse_modes(input: &str) -> Vec<Self> {
+        input.split(":").skip(1).map(CustomModeItem::parse).collect()
+    }
+}

--- a/src/devices/ak_series.rs
+++ b/src/devices/ak_series.rs
@@ -1,6 +1,7 @@
 use crate::{error, monitor::cpu::Cpu};
 use hidapi::HidApi;
 use std::{process::exit, thread::sleep, time::Duration};
+use crate::custom_mode::CustomModeItem;
 
 const VENDOR: u16 = 0x3633;
 const POLLING_RATE: u64 = 750;
@@ -52,6 +53,15 @@ impl Display {
                     device.write(&self.status_message(&data, "usage")).unwrap();
                 }
             }
+        } else if mode.starts_with("custom:") {
+            let modes = CustomModeItem::parse_modes(mode);
+            loop {
+                for mode in modes.iter() {
+                    for _ in 0..(mode.tick_length) {
+                        device.write(&self.status_message(&data, mode.mode.as_str())).unwrap();
+                    }
+                }
+            }
         } else {
             loop {
                 device.write(&self.status_message(&data, &mode)).unwrap();
@@ -88,7 +98,15 @@ impl Display {
                 data[4] = usage % 100 / 10;
                 data[5] = usage % 10;
             }
-            _ => (),
+            other => {
+                if other.starts_with("number.") {
+                    let value = other.split(".").skip(1).next().unwrap().parse::<u16>().unwrap().min(999);
+                    data[1] = 19;
+                    data[3] = (value / 100) as u8;
+                    data[4] = (value % 100 / 10) as u8;
+                    data[5] = (value % 10) as u8;
+                }
+            }
         }
         // Status bar
         data[2] = if usage < 15 { 1 } else { (usage as f32 / 10.0).round() as u8 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod devices;
 mod monitor;
+mod custom_mode;
 
 use colored::*;
 use hidapi::HidApi;
@@ -199,7 +200,7 @@ fn read_args() -> Args {
             "-m" | "--mode" => {
                 if i + 1 < args.len() {
                     mode = args[i + 1].clone();
-                    if ["temp", "usage", "power", "auto"].contains(&mode.as_str()) {
+                    if ["temp", "usage", "power", "auto"].contains(&mode.as_str()) || mode.starts_with("custom:") {
                         i += 1;
                     } else {
                         error!("Invalid mode");


### PR DESCRIPTION
This PR implements two features:
- A custom scheduling mode that allows the user to pick and match display modes and how long they're displayed, for example: `--mode "custom:temp,2:usage,4"` shows temperature for 2 ticks (1500ms) and usage for 4 ticks (3000ms).
- A number display mode that allows the display of custom numbers, for example: `--mode "custom:number.32,1:number.64,1"` changes between 32 and 64 every tick (750ms).

Currently it is only implemented for the AK series as it's the only device I have access to.