### PR TITLE
Add support for AK400 PRO

### DIFF
--- a/device-list/README.md
+++ b/device-list/README.md
@@ -8,7 +8,7 @@
         <th>USB Data Bytes</th>
     </tr>
     <tr>
-        <td rowspan="16">13875</td>
+        <td rowspan="18">13875</td>
         <td>1</td>
         <td>AK400 DIGITAL</td>
         <td align="center" rowspan="4">
@@ -80,6 +80,18 @@
     </tr>
     <tr>
         <td>LD360</td>
+    </tr>
+    <tr>
+        <td>...</td>
+        <td>...</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>16</td>
+        <td>AK400 PRO</td>
+        <td align="center">
+            <a href="tables/ak400-pro.md">Mapping Table</a>
+        </td>
     </tr>
     <tr>
         <td>...</td>

--- a/device-list/tables/ak400-pro.md
+++ b/device-list/tables/ak400-pro.md
@@ -1,0 +1,93 @@
+# AK400 DIGITAL PRO Mapping Table
+<table>
+    <tr>
+        <th>DATA BYTE</th>
+        <th>VALUE</th>
+        <th>FUNCTION</th>
+    </tr>
+    <tr>
+        <td>D0</td>
+        <td>16</td>
+        <td>REPORT ID</td>
+    </tr>
+    <tr>
+        <td>D1</td>
+        <td>104</td>
+        <td rowspan="7">PREAMBLE BYTES <sup>UNCLARIFIED</sup></td>
+    </tr>
+    <tr>
+        <td>D2</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>D3</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>D4</td>
+        <td>11</td>
+    </tr>
+    <tr>
+        <td>D5</td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td>D6</td>
+        <td>2</td>
+    </tr>
+    <tr>
+        <td>D7</td>
+        <td>5</td>
+    </tr>
+    <tr>
+        <td>D8</td>
+        <td>0-255</td>
+        <td rowspan="2">POWER CONSUMPTION <sup><code>U16</code></sup></td>
+    </tr>
+    <tr>
+        <td>D9</td>
+        <td>1-255</td>
+    </tr>
+    <tr>
+        <td>D10</td>
+        <td>0-1</td>
+        <td>TEMPERATURE UNIT ˚C / ˚F</td>
+    </tr>
+    <tr>
+        <td>D11</td>
+        <td>0-255</td>
+        <td rowspan="4">TEMPERATURE <sup><code>F32</code></sup></td>
+    </tr>
+    <tr>
+        <td>D12</td>
+        <td>0-255</td>
+    </tr>
+    <tr>
+        <td>D13</td>
+        <td>0-255</td>
+    </tr>
+    <tr>
+        <td>D14</td>
+        <td>1-255</td>
+    </tr>
+    <tr>
+        <td>D15</td>
+        <td>0-100</td>
+        <td>UTILIZATION</td>
+    </tr>
+    <tr>
+        <td>D16</td>
+        <td>0-255</td>
+        <td>D1-D15 CHECKSUM <sup><code>U8</code> REMAINDER</sup></td>
+    </tr>
+    <tr>
+        <td>D17</td>
+        <td>22</td>
+        <td>TERMINATION BYTE</td>
+    </tr>
+    <tr>
+        <td>...</td>
+        <td>...</td>
+        <td>- NOT USED -</td>
+    </tr>
+</table>

--- a/src/devices/ak400_pro.rs
+++ b/src/devices/ak400_pro.rs
@@ -1,0 +1,88 @@
+use crate::{error, monitor::cpu::Cpu};
+use super::{device_error, Mode};
+use hidapi::HidApi;
+use std::{process::exit, thread::sleep, time::Duration};
+
+pub const DEFAULT_MODE: Mode = Mode::Auto;
+pub const POLLING_RATE: u64 = 750;
+// The temperature limits are hard-coded in the device
+// pub const TEMP_WARM_C: u8 = 80;
+// pub const TEMP_WARM_F: u8 = 176;
+pub const TEMP_HOT_C: u8 = 90;
+pub const TEMP_HOT_F: u8 = 194;
+
+
+pub struct Display {
+    fahrenheit: bool,
+    cpu: Cpu,
+}
+
+impl Display {
+    pub fn new(fahrenheit: bool) -> Self {
+        Display {
+            fahrenheit,
+            cpu: Cpu::new(),
+        }
+    }
+
+    pub fn run(&self, api: &HidApi, vid: u16, pid: u16) {
+        // Connect to device
+        let device = api.open(vid, pid).unwrap_or_else(|_| device_error());
+
+
+        // Check if `rapl_max_uj` was read correctly
+        if self.cpu.rapl_max_uj == 0 {
+            error!("Failed to get CPU power details");
+            exit(1);
+        }
+
+        // Data packet
+        let mut data: [u8; 64] = [0; 64];
+        data[0] = 16;
+        data[1] = 104;
+        data[2] = 1;
+        data[3] = 2;
+
+        // Display loop
+        data[4] = 11;
+        data[5] = 1;
+        data[6] = 2;
+        data[7] = 5;
+
+        loop {
+            // Initialize the packet
+            let mut status_data = data.clone();
+
+            // Read CPU utilization & energy consumption
+            let cpu_instant = self.cpu.read_instant();
+            let cpu_energy = self.cpu.read_energy();
+
+            // Wait
+            sleep(Duration::from_millis(POLLING_RATE));
+
+            // ----- Write data to the package -----
+            // Power consumption
+            let power = (self.cpu.get_power(cpu_energy, POLLING_RATE)).to_be_bytes();
+            status_data[8] = power[0];
+            status_data[9] = power[1];
+
+            // Temperature
+            let temp = (self.cpu.get_temp(self.fahrenheit) as f32).to_be_bytes();
+            status_data[10] = if self.fahrenheit { 1 } else { 0 };
+            status_data[11] = temp[0];
+            status_data[12] = temp[1];
+            status_data[13] = temp[2];
+            status_data[14] = temp[3];
+
+            // Utilization
+            status_data[15] = self.cpu.get_usage(cpu_instant);
+
+            // Checksum & termination byte
+            let checksum: u16 = status_data[1..=15].iter().map(|&x| x as u16).sum();
+            status_data[16] = (checksum % 256) as u8;
+            status_data[17] = 22;
+
+            device.write(&status_data).unwrap();
+        }
+    }
+}

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,5 +1,6 @@
 pub mod ag_series;
 pub mod ak_series;
+pub mod ak400_pro;
 pub mod ch_series;
 pub mod ch510;
 pub mod ld_series;

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,34 @@ fn main() {
             // Display loop
             ld_device.run(&api, DEFAULT_VENDOR_ID, product_id);
         }
+        // AK400 PRO
+        16 => {
+            println!("Supported modes: {}", "auto".bold());
+            // Connect to device
+            let ak400_pro = devices::ak400_pro::Display::new(args.fahrenheit);
+            // Print current configuration & warnings
+            print_device_status(
+                ak400_pro::DEFAULT_MODE,
+                if args.fahrenheit { TemperatureUnit::Fahrenheit } else { TemperatureUnit::Celsius },
+                    Alarm {
+                        state: AlarmState::Auto,
+                        temp_limit: if args.fahrenheit {
+                            ak400_pro::TEMP_HOT_F
+                        } else {
+                            ak400_pro::TEMP_HOT_C
+                        },
+                    },
+                    ak400_pro::POLLING_RATE,
+            );
+            if args.mode != Mode::Default {
+                warning!("Display mode cannot be changed, value will be ignored");
+            }
+            if args.alarm {
+                warning!("The alarm is hard-coded in your device, value will be ignored");
+            }
+            // Display loop
+            ak400_pro.run(&api, DEFAULT_VENDOR_ID, product_id);
+        }
         // CH Series & MORPHEUS
         5 | 7 | 21 => {
             println!("Supported modes: {} [default: {}]", "auto temp usage".bold(), ch_series::DEFAULT_MODE.symbol());


### PR DESCRIPTION
I've taken a look at the packets and modified a few things from the LD series code.

The packet structure is the same as the LD series and the preamble is almost the same, only one byte differs - D3 is 2 instead of 1 (although this doesn't appear to have an effect on the functionality).

The AK400 PRO doesn't have a boot animation so I removed the initialisation sequence entirely, and this simultaneously fixed the leading 0s issue. Just out of curiosity I found out that [this line](https://github.com/Nortank12/deepcool-digital-linux/blob/main/src/devices/ld_series.rs#L51) seemed to be responsible for having them appear.

This cooler has multiple temperature limits for its alarm:
> The temperature warning alert system has also been upgraded to have a color-coded visual indicator: under 80 °C, the indicator will stay green; between 80 and 90°C, it will be a bright orange; when things get warm above 90 °C, it will go red, and you will start to see flashes. - [Deepcool AK400 Digital PRO](https://www.deepcool.com/products/Cooling/cpuaircoolers/AK400-Digital-Pro-Cooler-With-Multi-line-Display-1851-1700-AM5/2024/18680.shtml)

so I wasn't sure how to print them in the device status (I've just left it to show the upper limit of 90 °C for now).

Aside from this, I've tested it and it seems to function identically to its Windows counterpart 😁