### PR TITLE
Fix Intel GPU detection to exclude iGPUs by presence of fan input

### DIFF
--- a/src/monitor/gpu/intel.rs
+++ b/src/monitor/gpu/intel.rs
@@ -92,10 +92,9 @@ fn find_hwmon_dir() -> String {
             for sensor in sensors {
                 let path = sensor.unwrap().path().to_str().unwrap().to_owned();
                 if let Ok(name) = read_to_string(format!("{}/name", path)) {
-                    if name.contains("i915") {
-                        if has_fans(&path) {
-                            return path;
-                        }
+                    // This is a generic check for Intel GPUs
+                    if name.contains("i915") || name.contains("intel") {
+                        return path;
                     }
                 }
             }
@@ -104,12 +103,6 @@ fn find_hwmon_dir() -> String {
     }
     error!("Failed to locate GPU temperature sensor (Intel)");
     exit(1);
-}
-
-/// Helper function to check if there are fans (Discrete card) present in the hwmon directory.
-fn has_fans(path: &str) -> bool {
-    // Check for fan1_input (indicating a fan is present)
-    std::path::Path::new(&format!("{}/fan1_input", path)).exists()
 }
 
 /// Looks for the DRM device directory corresponding to Intel GPUs in /sys/class/drm.

--- a/src/monitor/gpu/mod.rs
+++ b/src/monitor/gpu/mod.rs
@@ -77,10 +77,11 @@ fn get_vendor() -> String {
             return "amd".to_owned();
         } else if device.ends_with("nvidia") {
             return "nvidia".to_owned();
-        } else if device.contains("i915") {
+        } else if device.contains("808656") || device.contains("8086E2") {
+            //56xx (ARC A series PCI_ID) and E2xx (Arc B series PCI_ID)
+            // can't use the name "i915", because it is used by the intel IGPUS too
             return "intel".to_owned();
         }
     }
-
     "".to_owned()
 }

--- a/src/monitor/gpu/mod.rs
+++ b/src/monitor/gpu/mod.rs
@@ -78,8 +78,16 @@ fn get_vendor() -> String {
         } else if device.ends_with("nvidia") {
             return "nvidia".to_owned();
         } else if device.contains("i915") {
-            // TODO: only accept Intel Arc GPUs
-            return "intel".to_owned();
+            let fields: Vec<&str> = device.split_whitespace().collect(); // creates a vector of substrings containing the PCI device information.
+            if fields.len() > 2 {
+                let pci_class = &fields[1][..2]; // PCI class code (first 2 hex digits)
+
+                // Exclude iGPUs: Class code 03 (Display Controller) + subclass 80 (iGPU)
+                if pci_class != "03" {
+                    return "intel".to_owned();
+                }
+            }
+
         }
     }
 

--- a/src/monitor/gpu/mod.rs
+++ b/src/monitor/gpu/mod.rs
@@ -1,8 +1,8 @@
 //! Reads live data from an AMD, NVIDIA, or Intel Arc GPU.
 
 mod amd;
-mod nvidia;
 mod intel;
+mod nvidia;
 
 use crate::{error, warning};
 use std::{fs::read_to_string, process::exit};
@@ -78,17 +78,7 @@ fn get_vendor() -> String {
         } else if device.ends_with("nvidia") {
             return "nvidia".to_owned();
         } else if device.contains("i915") {
-            let fields: Vec<&str> = device.split_whitespace().collect(); // creates a vector of substrings containing the PCI device information.
-            if fields.len() > 2 {
-                let pci_class = &fields[1][..2]; // PCI class code (first 2 hex digits)
-                let pci_subclass = &fields[1][2..4];
-
-                // Exclude iGPUs: Class code 03 (Display Controller) + subclass 80 (iGPU)
-                if pci_class == "03" && pci_subclass != "80" {
-                    return "intel".to_owned();
-                }
-            }
-
+            return "intel".to_owned();
         }
     }
 

--- a/src/monitor/gpu/mod.rs
+++ b/src/monitor/gpu/mod.rs
@@ -81,9 +81,10 @@ fn get_vendor() -> String {
             let fields: Vec<&str> = device.split_whitespace().collect(); // creates a vector of substrings containing the PCI device information.
             if fields.len() > 2 {
                 let pci_class = &fields[1][..2]; // PCI class code (first 2 hex digits)
+                let pci_subclass = &fields[1][2..4];
 
                 // Exclude iGPUs: Class code 03 (Display Controller) + subclass 80 (iGPU)
-                if pci_class != "03" {
+                if pci_class == "03" && pci_subclass != "80" {
                     return "intel".to_owned();
                 }
             }


### PR DESCRIPTION
I added on the intel.rs a check for presence of fan_input 1, to make sure it has a intel discrete card. I tried some more conventional ways of doing it, without success. 
I tested it, but because I don't have an intel processor with integrated graphics, I can't be fully sure it is working 100%.