### PR TITLE
Add support for NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,19 @@
+export DIRENV_LOG_FORMAT="direnv: error %s"
+
+if [[ -d ".devenv" ]]; then
+  CHECKSUM_FILE=".devenv/.file_checksums"
+  CURRENT_CHECKSUMS=$(find . -maxdepth 1 -name "flake.lock" -o -name ".envrc" | sort | xargs sha256sum)
+  
+  if [[ -f "$CHECKSUM_FILE" ]]; then
+    STORED_CHECKSUMS=$(cat "$CHECKSUM_FILE")
+    if [[ "$STORED_CHECKSUMS" != "$CURRENT_CHECKSUMS" ]]; then
+      echo "flake.lock or .envrc changed - cleaning up .devenv directory..."
+      rm -rf .devenv
+    fi
+  fi
+  
+  mkdir -p .devenv
+  echo "$CURRENT_CHECKSUMS" > "$CHECKSUM_FILE"
+fi
+
+use_flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 debug/
 target/
+result
 **/*.rs.bk
 *.pdb
+.*/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756469547,
+        "narHash": "sha256-YvtD2E7MYsQ3r7K9K2G7nCslCKMPShoSEAtbjHLtH0k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "41d292bfc37309790f70f4c120b79280ce40af16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756607787,
+        "narHash": "sha256-ciwAdgtlAN1PCaidWK6RuWsTBL8DVuyDCGM+X3ein5Q=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f46d294b87ebb9f7124f1ce13aa2a5f5acc0f3eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Linux version for the DeepCool Digital Windows software";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    (inputs.flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ (import inputs.rust-overlay) ];
+        };
+      in
+      {
+        packages.default = pkgs.callPackage ./nix/package.nix {
+          inherit inputs;
+          projectRoot = builtins.path { path = ./.; };
+        };
+
+        devShells.default = import ./nix/devShell.nix pkgs;
+      }
+    ))
+    // {
+      nixosModules.default = import ./nix/module.nix inputs.self;
+    };
+}

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,31 @@
+pkgs:
+let
+  rustDevEnv = (
+    pkgs.rust-bin.stable.latest.default.override {
+      extensions = [ "rust-src" ];
+    }
+  );
+in
+pkgs.mkShell {
+  packages =
+    with pkgs;
+    [
+      pkg-config
+      libudev-zero
+    ]
+    ++ [ rustDevEnv ];
+
+  shellHook = ''
+    [ -d ".devenv/profile" ] && exit 0
+    mkdir -p .devenv/profile/{bin,lib/rustlib/src}
+
+    ln -sfn ${rustDevEnv}/bin/* .devenv/profile/bin/
+    ln -sfn ${rustDevEnv}/lib/rustlib/src/rust .devenv/profile/lib/rustlib/src/rust
+
+    echo ""
+    echo "Development environment initialized with local toolchain paths"
+    echo "Toolchain: $PWD/.devenv/profile/bin"
+    echo "Standard library: $PWD/.devenv/profile/lib/rustlib/src/rust/library"
+    echo ""
+  '';
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,140 @@
+flake:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    mkIf
+    types
+    optionals
+    ;
+  cfg = config.hardware.deepcool-digital-linux;
+  pkg = cfg.package;
+
+  daemonArgs = lib.escapeShellArgs (
+    [ ]
+    ++ optionals (cfg.systemd.mode != null) [
+      "--mode"
+      cfg.systemd.mode
+    ]
+    ++ optionals (cfg.systemd.secondary != null) [
+      "--secondary"
+      cfg.systemd.secondary
+    ]
+    ++ optionals (cfg.systemd.pid != null) [
+      "--pid"
+      (toString cfg.systemd.pid)
+    ]
+    ++ optionals (cfg.systemd.updateMs != null) [
+      "--update"
+      (toString cfg.systemd.updateMs)
+    ]
+    ++ optionals cfg.systemd.fahrenheit [ "--fahrenheit" ]
+    ++ optionals cfg.systemd.alarm [ "--alarm" ]
+  );
+in
+{
+  options.hardware.deepcool-digital-linux = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable the DeepCool digital software";
+    };
+    package = mkOption {
+      type = types.package;
+      default = flake.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      description = "Set DeepCool Digital package to be used";
+    };
+
+    systemd = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Enable the systemd service for DeepCool Digital";
+      };
+
+      mode = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "auto"
+            "cpu_freq"
+            "cpu_fan"
+            "gpu"
+            "psu"
+          ]
+        );
+        default = null;
+        description = "Change the display mode of your device";
+      };
+
+      secondary = mkOption {
+        type = types.nullOr (
+          types.enum [
+            "auto"
+            "cpu_freq"
+            "cpu_fan"
+            "gpu"
+            "psu"
+          ]
+        );
+        default = null;
+        description = "Change the secondary display mode of your device (if supported)";
+      };
+
+      pid = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = "Specify the Product ID if you use multiple devices";
+      };
+
+      updateMs = mkOption {
+        type = types.nullOr (types.ints.between 100 2000);
+        default = null;
+        description = "Change the update interval of the display in milliseconds";
+      };
+
+      fahrenheit = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Change the temperature unit to °F";
+      };
+
+      alarm = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable the alarm";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable ({
+    environment.systemPackages = [ pkg ];
+
+    systemd.services.deepcool-digital-linux = mkIf cfg.systemd.enable {
+      description = "DeepCool Digital Software Daemon";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkg}/bin/deepcool-digital-linux ${daemonArgs}";
+        Restart = "on-failure";
+      };
+    };
+
+    services.udev.packages = [
+      (pkgs.writeTextDir "etc/udev/rules.d/41-deepcool-digital-linux.rules" ''
+        # Intel RAPL energy usage file
+        ACTION=="add", SUBSYSTEM=="powercap", KERNEL=="intel-rapl:0", RUN+="${pkgs.coreutils}/bin/chmod 444 /sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj"
+
+        # DeepCool HID raw devices
+        SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3633", MODE="0666"
+
+        # CH510 MESH DIGITAL
+        SUBSYSTEM=="hidraw", ATTRS{idVendor}=="34d3", ATTRS{idProduct}=="1100", MODE="0666"
+      '')
+    ];
+  });
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,28 @@
+{
+  rustPlatform,
+  pkg-config,
+  libudev-zero,
+  projectRoot,
+  ...
+}:
+let
+  lockFile = "${projectRoot}/Cargo.lock";
+  tomlFile = builtins.fromTOML (builtins.readFile "${projectRoot}/Cargo.toml");
+
+  requiredInputs = [
+    pkg-config
+    libudev-zero
+  ];
+in
+rustPlatform.buildRustPackage {
+  pname = tomlFile.package.name;
+  version = tomlFile.package.version;
+
+  src = projectRoot;
+  cargoLock = {
+    inherit lockFile;
+  };
+
+  buildInputs = requiredInputs;
+  nativeBuildInputs = requiredInputs;
+}

--- a/src/monitor/gpu/nvidia.rs
+++ b/src/monitor/gpu/nvidia.rs
@@ -18,7 +18,7 @@ struct Utilization {
     memory: u32,
 }
 
-const LIB_PATHS: [&str; 10] = [
+const LIB_PATHS: [&str; 12] = [
     "/usr/lib/x86_64-linux-gnu/nvidia/current/libnvidia-ml.so",
     "/usr/lib/x86_64-linux-gnu/nvidia/current/libnvidia-ml.so.1",
     "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so",
@@ -29,6 +29,8 @@ const LIB_PATHS: [&str; 10] = [
     "/usr/lib64/libnvidia-ml.so.1",
     "/usr/lib32/libnvidia-ml.so",
     "/usr/lib32/libnvidia-ml.so.1",
+    "/run/opengl-driver/lib/libnvidia-ml.so",
+    "/run/opengl-driver/lib/libnvidia-ml.so.1",
 ];
 
 pub struct Gpu {


### PR DESCRIPTION
In this pull request, I am making 3 changes:
- Fixed Nvidia library path, as NixOS doesn't find libraries in the specified directories. Used the most generic path instead.
- Added Nix flake which provides a streamlined way to build the application with automatic dependency resolution.
- Added direnv integration with flake, so RustRover (and other IDEs) can be easily configured to use the proper toolchain and SDK.

Please let me know if you're okay with these changes, and I will update the documentation.