### PR TITLE
Support asus-ec-sensors for CPU temperature monitoring

### DIFF
--- a/src/monitor/cpu.rs
+++ b/src/monitor/cpu.rs
@@ -104,7 +104,7 @@ fn find_temp_sensor() -> String {
                 let path = sensor.unwrap().path().to_str().unwrap().to_owned();
                 match read_to_string(format!("{path}/name")) {
                     Ok(name) => {
-                        if ["coretemp", "k10temp", "zenpower"].contains(&name.trim_end()) {
+                        if ["asusec", "coretemp", "k10temp", "zenpower"].contains(&name.trim_end()) {
                             return format!("{path}/temp1_input");
                         }
                     }


### PR DESCRIPTION
This change adds `asusec` to the list of recognized CPU temperature sensors. The ASUS embedded controller maintains temperature readings that are consistently synchronized with BIOS values (in reality with `NCT6701D` chip, but the chip don't have support in Linux yet), providing more reliable temperature monitoring on systems with `asus-ec-sensors` support.

While I'm not certain if this change should be upstreamed, it significantly improves temperature monitoring accuracy for ASUS systems with embedded controller sensor support.