### PR TITLE
Avoid exiting when CPU power sensor is unavailable

### DIFF
--- a/src/monitor/cpu.rs
+++ b/src/monitor/cpu.rs
@@ -56,10 +56,10 @@ impl Cpu {
     /// Reads the energy consumption of the CPU in microjoules.
     pub fn read_energy(&self) -> u64 {
         if self.rapl_max_uj > 0 {
-            let data = read_to_string("/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj").unwrap_or_else(|_| {
-                error!("Failed to get CPU power");
-                exit(1);
-            });
+            let data = match read_to_string("/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj") {
+                Ok(data) => data,
+                Err(_) => return 0,
+            };
             return data.trim_end().parse::<u64>().unwrap();
         }
 


### PR DESCRIPTION
## Summary

Avoid terminating the application when the Intel RAPL CPU power sensor is unavailable.

The current implementation exits when this path cannot be read:

/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj

This prevents the display from receiving any data on AMD systems where Intel RAPL is not present.

## Change

Return a fallback power value of 0 instead of exiting the process when the power sensor cannot be read.

## Tested on

- DeepCool AK620 G2 DIGITAL NYX
- AMD Ryzen 7 9850X3D
- Bazzite 44 / Fedora 44
- deepcool-digital-linux v0.10.6-alpha

The display now starts correctly and continues updating automatically through a systemd user service.