### PR TITLE
Add AMD CPU power monitoring via hwmon

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You will need root permission to send data to the device.
 > For more accurate CPU temperature monitoring, you can use the [zenpower3](https://github.com/PutinVladimir/zenpower3)
 > or [asus-ec-sensors](https://github.com/zeule/asus-ec-sensors) kernel modules on supported hardware.
 
+CPU power monitoring supports Intel RAPL and the AMD `zenergy`/`amd_energy` hwmon drivers.
+
 > [!NOTE]
 > On Intel's Arc GPUs, you have to use kernel version 6.13 or higher for proper temperature monitoring.
 

--- a/src/monitor/cpu.rs
+++ b/src/monitor/cpu.rs
@@ -2,18 +2,28 @@
 
 use crate::{error, warning};
 use cpu_monitor::CpuInstant;
-use std::{fs::{read_dir, read_to_string, File}, io::{BufRead, BufReader}, process::exit};
+use std::{
+    fs::{read_dir, read_to_string, File},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+struct EnergySensor {
+    path: PathBuf,
+    max_uj: Option<u64>,
+}
 
 pub struct Cpu {
     temp_sensor: Option<String>,
-    rapl_max_uj: u64,
+    energy_sensor: Option<EnergySensor>,
 }
 
 impl Cpu {
     pub fn new() -> Self {
         Cpu {
             temp_sensor: find_temp_sensor(),
-            rapl_max_uj: get_max_energy(),
+            energy_sensor: find_energy_sensor(),
         }
     }
 
@@ -26,10 +36,10 @@ impl Cpu {
         }
     }
 
-    /// Displays a warning message if RAPL module is not initialized.
+    /// Displays a warning message if no supported CPU energy counter is available.
     pub fn warn_rapl(&self) {
-        if self.rapl_max_uj == 0 {
-            warning!("RAPL module was not found");
+        if self.energy_sensor.is_none() {
+            warning!("No supported CPU energy sensor was found");
             eprintln!("         CPU power consumption will not be displayed.");
         }
     }
@@ -55,8 +65,8 @@ impl Cpu {
 
     /// Reads the energy consumption of the CPU in microjoules.
     pub fn read_energy(&self) -> u64 {
-        if self.rapl_max_uj > 0 {
-            let data = read_to_string("/sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj").unwrap_or_else(|_| {
+        if let Some(sensor) = &self.energy_sensor {
+            let data = read_to_string(&sensor.path).unwrap_or_else(|_| {
                 error!("Failed to get CPU power");
                 exit(1);
             });
@@ -70,13 +80,16 @@ impl Cpu {
     ///
     /// Formula: `W = ΔμJ / (Δms * 1000)`
     pub fn get_power(&self, initial_energy: u64, delta_millisec: u64) -> u16 {
-        if self.rapl_max_uj > 0 {
+        if let Some(sensor) = &self.energy_sensor {
             let current_energy = self.read_energy();
             let delta_energy = if current_energy > initial_energy {
                 current_energy - initial_energy
+            } else if let Some(max_uj) = sensor.max_uj {
+                // Offset the current measurement if a bounded counter wraps.
+                (max_uj + current_energy) - initial_energy
             } else {
-                // Offset the current measurement if the counter resets
-                (self.rapl_max_uj + current_energy) - initial_energy
+                // Unbounded hwmon counters only decrease when the sensor resets.
+                return 0;
             };
             return (delta_energy as f64 / (delta_millisec * 1000) as f64).round() as u16;
         }
@@ -135,12 +148,62 @@ fn find_temp_sensor() -> Option<String> {
     None
 }
 
-/// Gets the limit of the displayed energy value so it can be applied as an offset when the counter resets.
-fn get_max_energy() -> u64 {
-    match read_to_string("/sys/class/powercap/intel-rapl/intel-rapl:0/max_energy_range_uj") {
-        Ok(data) => data.trim_end().parse::<u64>().unwrap(),
-        Err(_) => 0,
+/// Finds an Intel RAPL or AMD zenergy/amd_energy package energy counter.
+fn find_energy_sensor() -> Option<EnergySensor> {
+    let intel_rapl = Path::new("/sys/class/powercap/intel-rapl/intel-rapl:0");
+    let intel_path = intel_rapl.join("energy_uj");
+    if intel_path.is_file() {
+        let max_uj = read_to_string(intel_rapl.join("max_energy_range_uj"))
+            .ok()
+            .and_then(|data| data.trim_end().parse::<u64>().ok());
+        return Some(EnergySensor {
+            path: intel_path,
+            max_uj,
+        });
     }
+
+    for entry in read_dir("/sys/class/hwmon").ok()?.flatten() {
+        let path = entry.path();
+        let Ok(name) = read_to_string(path.join("name")) else {
+            continue;
+        };
+        if !["zenergy", "amd_energy"].contains(&name.trim_end()) {
+            continue;
+        }
+
+        if let Some(path) = find_socket_energy(&path) {
+            return Some(EnergySensor { path, max_uj: None });
+        }
+    }
+
+    None
+}
+
+/// Finds the package/socket energy channel exposed by an AMD hwmon device.
+fn find_socket_energy(hwmon: &Path) -> Option<PathBuf> {
+    for entry in read_dir(hwmon).ok()?.flatten() {
+        let label_path = entry.path();
+        let Some(file_name) = label_path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        let Some(channel) = file_name
+            .strip_prefix("energy")
+            .and_then(|name| name.strip_suffix("_label"))
+        else {
+            continue;
+        };
+        let Ok(label) = read_to_string(&label_path) else {
+            continue;
+        };
+        if label.trim_end().starts_with("Esocket") {
+            let input_path = hwmon.join(format!("energy{channel}_input"));
+            if input_path.is_file() {
+                return Some(input_path);
+            }
+        }
+    }
+
+    None
 }
 
 /// Gets the CPU model name.


### PR DESCRIPTION
Adds CPU power monitoring support for AMD processors while preserving the existing Intel RAPL implementation.

AMD energy counters are exposed through the hwmon interface by the `zenergy` or `amd_energy` driver. The program now finds the package-level `Esocket` channel and calculates CPU power from its cumulative microjoule counter.

## Changes

- Keep using Intel RAPL when available.
- Detect `zenergy` and `amd_energy` hwmon devices.
- Select the package-level `Esocket` energy counter instead of per-core counters.
- Handle AMD counter resets without reporting an invalid power spike.
